### PR TITLE
Bumping the omniauth version to fix a vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Estratégia omniauth para integração do Login Único do governo brasileiro ao 
 ## Instalação
 
 ```ruby
-gem 'omniauth', '1.9.1'
+gem 'omniauth', '1.9.2'
 gem "omniauth-rails_csrf_protection", '0.1.2'
 gem 'omniauth-oauth2'
-gem 'omniauth-gov', '~> 0.1.8'
+gem 'omniauth-gov', '~> 0.1.9'
 ```
 
 ## Configuração devise

--- a/lib/omniauth-gov/version.rb
+++ b/lib/omniauth-gov/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Gov
-    VERSION = "0.1.8"
+    VERSION = "0.1.9"
   end
 end

--- a/omniauth-gov.gemspec
+++ b/omniauth-gov.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Gov::VERSION
 
-  gem.add_dependency 'omniauth', '>= 1.9.2', '< 2.0'
+  gem.add_dependency 'omniauth', '~> 2.0'
   gem.add_dependency 'omniauth-oauth2'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'faraday', '~> 2.9'

--- a/omniauth-gov.gemspec
+++ b/omniauth-gov.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Gov::VERSION
 
-  gem.add_dependency 'omniauth', '1.9.1' 
+  gem.add_dependency 'omniauth', '>= 1.9.2', '< 2.0'
   gem.add_dependency 'omniauth-oauth2'
   gem.add_development_dependency 'rspec', '~> 3.5'
   gem.add_development_dependency 'faraday', '~> 2.9'


### PR DESCRIPTION
Updating this dependency to fix the [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-36599) found on the 1.9.1.

Here are the [changes](https://github.com/omniauth/omniauth/compare/v1.9.1...v1.9.2) of the 1.9.2 version, which should not be a problem here, as they are just a escape function from Rack.